### PR TITLE
DEV-125419: Add key_column and unordered support to changefeed

### DIFF
--- a/postgresql/resource_cockroachdb_changefeed.go
+++ b/postgresql/resource_cockroachdb_changefeed.go
@@ -21,6 +21,8 @@ const (
 	CDCInitialScan            = "initial_scan"
 	CDCCompression            = "compression"
 	CDCCompressionLevel       = "compression_level"
+	CDCKeyColumn              = "key_column"
+	CDCUnordered              = "unordered"
 )
 
 func resourceCockroachDBChangefeed() *schema.Resource {
@@ -90,6 +92,19 @@ func resourceCockroachDBChangefeed() *schema.Resource {
 				Description: "Kafka sink compression level. Defaults to 0 (fastest).",
 				ForceNew:    true,
 			},
+			CDCKeyColumn: {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Column name to use as the changefeed message key instead of the primary key.",
+				ForceNew:    true,
+			},
+			CDCUnordered: {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Whether the changefeed is unordered. Must be true when key_column is set.",
+				ForceNew:    true,
+			},
 		},
 	}
 }
@@ -100,6 +115,12 @@ func resourceCockroachDBChangefeedCreate(db *DBConnection, d *schema.ResourceDat
 	registryConnectionName := d.Get(CDCRegistryConnectionName).(string)
 	avroSchemaPrefix := d.Get(CDCAvroSchemaPrefix).(string)
 	startFrom := d.Get(CDCStartFrom).(string)
+	keyColumn := d.Get(CDCKeyColumn).(string)
+	unordered := d.Get(CDCUnordered).(bool)
+
+	if keyColumn != "" && !unordered {
+		return fmt.Errorf("unordered must be true when key_column is set")
+	}
 
 	database := db.client.databaseName
 
@@ -125,11 +146,21 @@ func resourceCockroachDBChangefeedCreate(db *DBConnection, d *schema.ResourceDat
 		)
 	}
 
+	var keyColumnClause string
+	if keyColumn != "" {
+		keyColumnClause = fmt.Sprintf(", key_column = '%s'", keyColumn)
+	}
+
+	var unorderedClause string
+	if unordered {
+		unorderedClause = ", unordered"
+	}
+
 	tableList := Interface2StringList(tableListInterface)
 	tableListStr := strings.Join(tableList, ", ")
 	sqlChangefeed := fmt.Sprintf(
-		`CREATE CHANGEFEED FOR TABLE %v INTO "external://%s" WITH %s updated, %s diff, on_error='pause', format = avro, avro_schema_prefix='%s_', confluent_schema_registry = 'external://%s'%s`,
-		tableListStr, kafkaConnectionName, initialScanClause, cursorClause, avroSchemaPrefix, registryConnectionName, kafkaSinkConfigClause,
+		`CREATE CHANGEFEED FOR TABLE %v INTO "external://%s" WITH %s updated, %s diff, on_error='pause', format = avro, avro_schema_prefix='%s_', confluent_schema_registry = 'external://%s'%s%s%s`,
+		tableListStr, kafkaConnectionName, initialScanClause, cursorClause, avroSchemaPrefix, registryConnectionName, kafkaSinkConfigClause, keyColumnClause, unorderedClause,
 	)
 	dbConn, err := connectToDatabase(db, database)
 	if err != nil {
@@ -183,7 +214,7 @@ func resourceCockroachDBChangefeedReadImpl(db *DBConnection, d *schema.ResourceD
 	// setting the sink uri
 	d.Set(CDCKafkaConnectionName, strings.TrimPrefix(sinkUri, "external://"))
 	// setting the avro schema prefix and confluent schema registry
-	avroSchemaPrefix, confluentSchemaRegistry, initialScanValue, cursorValue, compression, compressionLevel := extractDetails(description)
+	avroSchemaPrefix, confluentSchemaRegistry, initialScanValue, cursorValue, compression, compressionLevel, keyColumn, unordered := extractDetails(description)
 	d.Set(CDCAvroSchemaPrefix, strings.TrimSuffix(avroSchemaPrefix, "_"))
 	d.Set(CDCRegistryConnectionName, confluentSchemaRegistry)
 	if initialScanValue == "yes" {
@@ -200,6 +231,8 @@ func resourceCockroachDBChangefeedReadImpl(db *DBConnection, d *schema.ResourceD
 		d.Set(CDCCompression, "NONE")
 	}
 	d.Set(CDCCompressionLevel, compressionLevel)
+	d.Set(CDCKeyColumn, keyColumn)
+	d.Set(CDCUnordered, unordered)
 
 	return nil
 }
@@ -332,7 +365,7 @@ func waitForJobStatus(db *DBConnection, jobID string, requestedStatus string, ti
 	}
 }
 
-func extractDetails(sql string) (string, string, string, string, string, int) {
+func extractDetails(sql string) (string, string, string, string, string, int, string, bool) {
 	// Regular expression to extract the avro_schema_prefix
 	avroSchemaPrefixRegex := regexp.MustCompile(`avro_schema_prefix\s*=\s*'([^']*)'`)
 	avroSchemaPrefixMatch := avroSchemaPrefixRegex.FindStringSubmatch(sql)
@@ -384,7 +417,19 @@ func extractDetails(sql string) (string, string, string, string, string, int) {
 		}
 	}
 
-	return avroSchemaPrefix, confluentSchemaRegistry, initialScan, cursor, compression, compressionLevel
+	// Extract key_column
+	keyColumnRegex := regexp.MustCompile(`key_column\s*=\s*'([^']*)'`)
+	keyColumnMatch := keyColumnRegex.FindStringSubmatch(sql)
+	keyColumn := ""
+	if len(keyColumnMatch) > 1 {
+		keyColumn = keyColumnMatch[1]
+	}
+
+	// Check for unordered option
+	unorderedRegex := regexp.MustCompile(`(?:^|[,\s])unordered(?:$|[,\s])`)
+	unordered := unorderedRegex.MatchString(sql)
+
+	return avroSchemaPrefix, confluentSchemaRegistry, initialScan, cursor, compression, compressionLevel, keyColumn, unordered
 }
 
 func Interface2StringList(interfaceList interface{}) []string {

--- a/postgresql/resource_cockroachdb_changefeed_test.go
+++ b/postgresql/resource_cockroachdb_changefeed_test.go
@@ -107,6 +107,8 @@ func TestExtractDetails(t *testing.T) {
 		expectedCursor           string
 		expectedCompression      string
 		expectedCompressionLevel int
+		expectedKeyColumn        string
+		expectedUnordered        bool
 	}{
 		{
 			name:                     "full description with cursor",
@@ -117,6 +119,8 @@ func TestExtractDetails(t *testing.T) {
 			expectedCursor:           "2023-01-01 00:00:00",
 			expectedCompression:      "",
 			expectedCompressionLevel: 0,
+			expectedKeyColumn:        "",
+			expectedUnordered:        false,
 		},
 		{
 			name:                     "initial_scan yes, no cursor",
@@ -127,6 +131,8 @@ func TestExtractDetails(t *testing.T) {
 			expectedCursor:           "",
 			expectedCompression:      "",
 			expectedCompressionLevel: 0,
+			expectedKeyColumn:        "",
+			expectedUnordered:        false,
 		},
 		{
 			name:                     "empty sql",
@@ -137,6 +143,8 @@ func TestExtractDetails(t *testing.T) {
 			expectedCursor:           "",
 			expectedCompression:      "",
 			expectedCompressionLevel: 0,
+			expectedKeyColumn:        "",
+			expectedUnordered:        false,
 		},
 		{
 			name:                     "prefix with underscore suffix",
@@ -147,6 +155,8 @@ func TestExtractDetails(t *testing.T) {
 			expectedCursor:           "",
 			expectedCompression:      "",
 			expectedCompressionLevel: 0,
+			expectedKeyColumn:        "",
+			expectedUnordered:        false,
 		},
 		{
 			name:                     "with LZ4 compression",
@@ -157,6 +167,8 @@ func TestExtractDetails(t *testing.T) {
 			expectedCursor:           "",
 			expectedCompression:      "LZ4",
 			expectedCompressionLevel: 0,
+			expectedKeyColumn:        "",
+			expectedUnordered:        false,
 		},
 		{
 			name:                     "with GZIP compression level 5",
@@ -167,12 +179,50 @@ func TestExtractDetails(t *testing.T) {
 			expectedCursor:           "",
 			expectedCompression:      "GZIP",
 			expectedCompressionLevel: 5,
+			expectedKeyColumn:        "",
+			expectedUnordered:        false,
+		},
+		{
+			name:                     "with key_column and unordered",
+			sql:                      `CREATE CHANGEFEED FOR TABLE outbox_events INTO 'external://kafka_crdb_cdc_chargeback_service_db_all_public' WITH OPTIONS (avro_schema_prefix = 'crdb_cdc_chargeback_service_db_all_public_', confluent_schema_registry = 'external://schema_registry_crdb_cdc_general_all_public', diff, format = 'avro', initial_scan = 'yes', key_column = 'aggregate_id', on_error = 'pause', unordered, updated)`,
+			expectedAvroPrefix:       "crdb_cdc_chargeback_service_db_all_public_",
+			expectedRegistry:         "schema_registry_crdb_cdc_general_all_public",
+			expectedInitialScan:      "yes",
+			expectedCursor:           "",
+			expectedCompression:      "",
+			expectedCompressionLevel: 0,
+			expectedKeyColumn:        "aggregate_id",
+			expectedUnordered:        true,
+		},
+		{
+			name:                     "with key_column without unordered",
+			sql:                      `CREATE CHANGEFEED FOR TABLE mytable INTO "external://kafka-conn" WITH initial_scan = 'no', updated, diff, on_error='pause', format = avro, avro_schema_prefix='myprefix_', confluent_schema_registry = 'external://registry-conn', key_column = 'my_col'`,
+			expectedAvroPrefix:       "myprefix_",
+			expectedRegistry:         "registry-conn",
+			expectedInitialScan:      "no",
+			expectedCursor:           "",
+			expectedCompression:      "",
+			expectedCompressionLevel: 0,
+			expectedKeyColumn:        "my_col",
+			expectedUnordered:        false,
+		},
+		{
+			name:                     "with unordered only",
+			sql:                      `CREATE CHANGEFEED FOR TABLE mytable INTO "external://kafka-conn" WITH initial_scan = 'no', updated, diff, on_error='pause', format = avro, avro_schema_prefix='myprefix_', confluent_schema_registry = 'external://registry-conn', unordered`,
+			expectedAvroPrefix:       "myprefix_",
+			expectedRegistry:         "registry-conn",
+			expectedInitialScan:      "no",
+			expectedCursor:           "",
+			expectedCompression:      "",
+			expectedCompressionLevel: 0,
+			expectedKeyColumn:        "",
+			expectedUnordered:        true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			prefix, registry, initialScan, cursor, compression, compressionLevel := extractDetails(tt.sql)
+			prefix, registry, initialScan, cursor, compression, compressionLevel, keyColumn, unordered := extractDetails(tt.sql)
 			if prefix != tt.expectedAvroPrefix {
 				t.Errorf("extractDetails() avroPrefix = %q, want %q", prefix, tt.expectedAvroPrefix)
 			}
@@ -190,6 +240,12 @@ func TestExtractDetails(t *testing.T) {
 			}
 			if compressionLevel != tt.expectedCompressionLevel {
 				t.Errorf("extractDetails() compressionLevel = %d, want %d", compressionLevel, tt.expectedCompressionLevel)
+			}
+			if keyColumn != tt.expectedKeyColumn {
+				t.Errorf("extractDetails() keyColumn = %q, want %q", keyColumn, tt.expectedKeyColumn)
+			}
+			if unordered != tt.expectedUnordered {
+				t.Errorf("extractDetails() unordered = %v, want %v", unordered, tt.expectedUnordered)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- Adds `key_column` option to `postgresql_crdb_changefeed` to allow using a non-primary-key column as the changefeed message key
- Adds `unordered` option (required when `key_column` is set, since non-PK key values can change)
- Validates that `unordered = true` when `key_column` is specified
- Parses both options from changefeed description on read/import

## Test plan
- [x] Unit tests for `extractDetails` with key_column, unordered, and combined scenarios
- [x] `go build ./...` passes
- [x] `go test ./postgresql/ -run 'Test[^A]' -count=1` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)