### PR TITLE
Fix role deletion across databases and grant_role read emergency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.57.0 (April 10, 2026)
+## 1.47.0 (April 10, 2026)
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.57.0 (April 10, 2026)
+
+### Bug Fixes
+
+- **role**: Fix role deletion failing when role owns objects in other databases — `REASSIGN OWNED BY` and `DROP OWNED BY` are now executed in every non-system database, not just the provider's default database ([DEV-128384](https://riskified.atlassian.net/browse/DEV-128384))
+- **grant_role**: Fix `postgresql_grant_role` read returning an error when the grant doesn't exist instead of removing the resource from state, causing plan failures on fresh databases ([DEV-128384](https://riskified.atlassian.net/browse/DEV-128384))
+
 ## 1.46.0  (April 10, 2026)
 
 ### Features

--- a/postgresql/helpers.go
+++ b/postgresql/helpers.go
@@ -227,6 +227,27 @@ func connectToDatabase(db *DBConnection, database string) (*DBConnection, error)
 	return db.client.config.NewClient(database).Connect()
 }
 
+// getDatabases returns the names of all non-template, non-system databases.
+// The CockroachDB "system" database is excluded because it uses the legacy
+// schema changer which does not support DROP OWNED BY.
+func getDatabases(db QueryAble) ([]string, error) {
+	rows, err := db.Query("SELECT datname FROM pg_database WHERE datistemplate = false AND datname != 'system'")
+	if err != nil {
+		return nil, fmt.Errorf("could not list databases: %w", err)
+	}
+	defer rows.Close()
+
+	var databases []string
+	for rows.Next() {
+		var dbname string
+		if err := rows.Scan(&dbname); err != nil {
+			return nil, fmt.Errorf("could not scan database name: %w", err)
+		}
+		databases = append(databases, dbname)
+	}
+	return databases, rows.Err()
+}
+
 func dbExists(db QueryAble, dbname string) (bool, error) {
 	err := db.QueryRow("SELECT datname FROM pg_database WHERE datname=$1", dbname).Scan(&dbname)
 	switch {

--- a/postgresql/resource_postgresql_grant_role.go
+++ b/postgresql/resource_postgresql_grant_role.go
@@ -1,7 +1,9 @@
 package postgresql
 
 import (
+	"database/sql"
 	"fmt"
+	"log"
 	"strconv"
 	"strings"
 
@@ -99,7 +101,13 @@ func readGrantRole(db *DBConnection, d *schema.ResourceData) error {
 
 	query := fmt.Sprintf(` with a as (show grants on role %s for %s) select member as role , role_name as grant_role, is_admin as with_admin_option from a;
 `, pq.QuoteIdentifier(d.Get("grant_role").(string)), pq.QuoteIdentifier(d.Get("role").(string)))
-	if err := db.QueryRow(query).Scan(values...); err != nil {
+	err := db.QueryRow(query).Scan(values...)
+	switch {
+	case err == sql.ErrNoRows:
+		log.Printf("[WARN] PostgreSQL grant role %s for %s not found, removing from state", d.Get("grant_role"), d.Get("role"))
+		d.SetId("")
+		return nil
+	case err != nil:
 		return fmt.Errorf("Error to show grants on role %s for %s :%w ", d.Get("grant_role"), d.Get("role"), err)
 	}
 

--- a/postgresql/resource_postgresql_role.go
+++ b/postgresql/resource_postgresql_role.go
@@ -259,11 +259,25 @@ func resourcePostgreSQLRoleDelete(db *DBConnection, d *schema.ResourceData) erro
 
 	if !d.Get(roleSkipReassignOwnedAttr).(bool) {
 		currentUser := db.client.config.getDatabaseUsername()
-		if _, err := db.Exec(fmt.Sprintf("REASSIGN OWNED BY %s TO %s", pq.QuoteIdentifier(roleName), pq.QuoteIdentifier(currentUser))); err != nil {
-			return fmt.Errorf("could not reassign owned by role %s to %s: %w", roleName, currentUser, err)
+
+		// REASSIGN OWNED BY and DROP OWNED BY are database-scoped, so we need
+		// to run them in every database where the role might own objects.
+		databases, err := getDatabases(db)
+		if err != nil {
+			return fmt.Errorf("could not list databases for role %s cleanup: %w", roleName, err)
 		}
-		if _, err := db.Exec(fmt.Sprintf("DROP OWNED BY %s", pq.QuoteIdentifier(roleName))); err != nil {
-			return fmt.Errorf("could not drop owned by role %s: %w", roleName, err)
+
+		for _, database := range databases {
+			dbConn, err := connectToDatabase(db, database)
+			if err != nil {
+				return fmt.Errorf("could not connect to database %s to reassign owned by role %s: %w", database, roleName, err)
+			}
+			if _, err := dbConn.Exec(fmt.Sprintf("REASSIGN OWNED BY %s TO %s", pq.QuoteIdentifier(roleName), pq.QuoteIdentifier(currentUser))); err != nil {
+				return fmt.Errorf("could not reassign owned by role %s to %s in database %s: %w", roleName, currentUser, database, err)
+			}
+			if _, err := dbConn.Exec(fmt.Sprintf("DROP OWNED BY %s", pq.QuoteIdentifier(roleName))); err != nil {
+				return fmt.Errorf("could not drop owned by role %s in database %s: %w", roleName, database, err)
+			}
 		}
 	}
 	if !d.Get(roleSkipDropRoleAttr).(bool) {


### PR DESCRIPTION
## Summary

- **Role deletion**: `REASSIGN OWNED BY` and `DROP OWNED BY` are now executed in every non-system database before dropping a role, fixing the error `role X cannot be dropped because some objects depend on it` when the role owns objects in databases other than the provider's default connection database. The CockroachDB `system` database is excluded as it does not support `DROP OWNED BY` via the declarative schema changer.
- **Grant role read**: `postgresql_grant_role` read now handles `sql.ErrNoRows` by removing the resource from state (setting ID to empty), so Terraform correctly plans a create instead of erroring with `sql: no rows in result set` on fresh/recreated databases.
- **Changelog**: Added version 1.57.0 entry.

## Test plan

- [ ] Verify role deletion works when role owns schema/tables in a non-default database
- [ ] Verify `terraform plan` succeeds on a fresh database where grant_role resources exist in state but not in the DB
- [ ] Verify `system` database is skipped during role cleanup (no `DROP OWNED BY` error)
- [ ] Run existing acceptance tests (`make testacc_crdb`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)