### PR TITLE
DEV-128387: Retry transient CRDB errors during refresh and apply

### DIFF
--- a/postgresql/config.go
+++ b/postgresql/config.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 	"unicode"
 
 	"github.com/blang/semver"
@@ -89,6 +90,8 @@ type Config struct {
 	Timeout           int
 	ConnectTimeoutSec int
 	MaxConns          int
+	MaxRetries        int
+	RetryMaxDelayMs   int
 	ExpectedVersion   semver.Version
 	SSLClientCert     *ClientCertificateConfig
 	SSLRootCertPath   string
@@ -182,6 +185,9 @@ func (c *Client) Connect() (*DBConnection, error) {
 		// we don't keep opened connection in case of the db has to be dropped in the plan.
 		db.SetMaxIdleConns(0)
 		db.SetMaxOpenConns(c.config.MaxConns)
+		// Recycle connections before LB / CRDB idle reapers kill them mid-query.
+		db.SetConnMaxLifetime(5 * time.Minute)
+		db.SetConnMaxIdleTime(30 * time.Second)
 
 		defaultVersion, _ := semver.Parse(defaultExpectedCockroachDBVersion)
 		version := &c.config.ExpectedVersion

--- a/postgresql/data_source_postgresql_schemas.go
+++ b/postgresql/data_source_postgresql_schemas.go
@@ -99,7 +99,7 @@ func dataSourcePostgreSQLSchemasRead(db *DBConnection, d *schema.ResourceData) e
 
 	query = applySchemaDataSourceQueryFilters(query, queryConcatKeyword, d)
 
-	rows, err := dbConn.Query(query)
+	rows, err := dbConn.QueryRetry(query)
 	if err != nil {
 		return err
 	}

--- a/postgresql/data_source_postgresql_sequences.go
+++ b/postgresql/data_source_postgresql_sequences.go
@@ -97,7 +97,7 @@ func dataSourcePostgreSQLSequencesRead(db *DBConnection, d *schema.ResourceData)
 
 	query = applySequenceDataSourceQueryFilters(query, queryConcatKeyword, d)
 
-	rows, err := dbConn.Query(query)
+	rows, err := dbConn.QueryRetry(query)
 	if err != nil {
 		return err
 	}

--- a/postgresql/data_source_postgresql_tables.go
+++ b/postgresql/data_source_postgresql_tables.go
@@ -105,7 +105,7 @@ func dataSourcePostgreSQLTablesRead(db *DBConnection, d *schema.ResourceData) er
 
 	query = applyTableDataSourceQueryFilters(query, queryConcatKeyword, d)
 
-	rows, err := dbConn.Query(query)
+	rows, err := dbConn.QueryRetry(query)
 	if err != nil {
 		return err
 	}

--- a/postgresql/helpers.go
+++ b/postgresql/helpers.go
@@ -37,11 +37,14 @@ func PGResourceExistsFunc(fn func(*DBConnection, *schema.ResourceData) (bool, er
 	}
 }
 
-// QueryAble is a DB connection (sql.DB/Tx)
+// QueryAble is a DB connection (sql.DB/Tx) with retry helpers.
 type QueryAble interface {
 	Exec(query string, args ...interface{}) (sql.Result, error)
 	Query(query string, args ...interface{}) (*sql.Rows, error)
 	QueryRow(query string, args ...interface{}) *sql.Row
+	QueryRetry(query string, args ...interface{}) (*sql.Rows, error)
+	QueryRowRetry(scan func(*sql.Row) error, query string, args ...interface{}) error
+	ExecRetry(query string, args ...interface{}) (sql.Result, error)
 }
 
 // pqQuoteLiteral returns a string literal safe for inclusion in a PostgreSQL
@@ -56,10 +59,11 @@ func pqQuoteLiteral(in string) string {
 
 func isMemberOfRole(db QueryAble, role, member string) (bool, error) {
 	var _rez int
-	err := db.QueryRow(
+	err := db.QueryRowRetry(
+		func(r *sql.Row) error { return r.Scan(&_rez) },
 		"SELECT 1 FROM pg_auth_members WHERE pg_get_userbyid(roleid) = $1 AND pg_get_userbyid(member) = $2",
 		role, member,
-	).Scan(&_rez)
+	)
 
 	switch {
 	case err == sql.ErrNoRows:
@@ -92,7 +96,7 @@ func grantRoleMembership(db QueryAble, role, member string) (bool, error) {
 	log.Printf("grantRoleMembership: granting %s to %s", role, member)
 
 	sql := fmt.Sprintf("GRANT %s TO %s", pq.QuoteIdentifier(role), pq.QuoteIdentifier(member))
-	if _, err := db.Exec(sql); err != nil {
+	if _, err := db.ExecRetry(sql); err != nil {
 		return false, fmt.Errorf("Error granting role %s to %s: %w", role, member, err)
 	}
 	return true, nil
@@ -116,7 +120,7 @@ func revokeRoleMembership(db QueryAble, role, member string) (bool, error) {
 	log.Printf("revokeRoleMembership: Revoke %s from %s", role, member)
 
 	sql := fmt.Sprintf("REVOKE %s FROM %s", pq.QuoteIdentifier(role), pq.QuoteIdentifier(member))
-	if _, err := db.Exec(sql); err != nil {
+	if _, err := db.ExecRetry(sql); err != nil {
 		return false, fmt.Errorf("Error revoking role %s from %s: %w", role, member, err)
 	}
 	return true, nil
@@ -231,7 +235,7 @@ func connectToDatabase(db *DBConnection, database string) (*DBConnection, error)
 // The CockroachDB "system" database is excluded because it uses the legacy
 // schema changer which does not support DROP OWNED BY.
 func getDatabases(db QueryAble) ([]string, error) {
-	rows, err := db.Query("SELECT datname FROM pg_database WHERE datistemplate = false AND datname != 'system'")
+	rows, err := db.QueryRetry("SELECT datname FROM pg_database WHERE datistemplate = false AND datname != 'system'")
 	if err != nil {
 		return nil, fmt.Errorf("could not list databases: %w", err)
 	}
@@ -249,7 +253,10 @@ func getDatabases(db QueryAble) ([]string, error) {
 }
 
 func dbExists(db QueryAble, dbname string) (bool, error) {
-	err := db.QueryRow("SELECT datname FROM pg_database WHERE datname=$1", dbname).Scan(&dbname)
+	err := db.QueryRowRetry(
+		func(r *sql.Row) error { return r.Scan(&dbname) },
+		"SELECT datname FROM pg_database WHERE datname=$1", dbname,
+	)
 	switch {
 	case err == sql.ErrNoRows:
 		return false, nil
@@ -261,7 +268,10 @@ func dbExists(db QueryAble, dbname string) (bool, error) {
 }
 
 func roleExists(db QueryAble, rolname string) (bool, error) {
-	err := db.QueryRow("SELECT 1 FROM pg_roles WHERE rolname=$1", rolname).Scan(&rolname)
+	err := db.QueryRowRetry(
+		func(r *sql.Row) error { return r.Scan(&rolname) },
+		"SELECT 1 FROM pg_roles WHERE rolname=$1", rolname,
+	)
 	switch {
 	case err == sql.ErrNoRows:
 		return false, nil
@@ -273,7 +283,10 @@ func roleExists(db QueryAble, rolname string) (bool, error) {
 }
 
 func schemaExists(db QueryAble, schemaname string) (bool, error) {
-	err := db.QueryRow("SELECT 1 FROM pg_namespace WHERE nspname=$1", schemaname).Scan(&schemaname)
+	err := db.QueryRowRetry(
+		func(r *sql.Row) error { return r.Scan(&schemaname) },
+		"SELECT 1 FROM pg_namespace WHERE nspname=$1", schemaname,
+	)
 	switch {
 	case err == sql.ErrNoRows:
 		return false, nil
@@ -285,7 +298,10 @@ func schemaExists(db QueryAble, schemaname string) (bool, error) {
 }
 
 func schemaExistsWithDB(db *DBConnection, schemaname string) (bool, error) {
-	err := db.QueryRow("SELECT 1 FROM pg_namespace WHERE nspname=$1", schemaname).Scan(&schemaname)
+	err := db.QueryRowRetry(
+		func(r *sql.Row) error { return r.Scan(&schemaname) },
+		"SELECT 1 FROM pg_namespace WHERE nspname=$1", schemaname,
+	)
 	switch {
 	case err == sql.ErrNoRows:
 		return false, nil

--- a/postgresql/helpers.go
+++ b/postgresql/helpers.go
@@ -43,7 +43,7 @@ type QueryAble interface {
 	Query(query string, args ...interface{}) (*sql.Rows, error)
 	QueryRow(query string, args ...interface{}) *sql.Row
 	QueryRetry(query string, args ...interface{}) (*sql.Rows, error)
-	QueryRowRetry(scan func(*sql.Row) error, query string, args ...interface{}) error
+	QueryRowRetry(query string, args ...interface{}) *RetryRow
 	ExecRetry(query string, args ...interface{}) (sql.Result, error)
 }
 
@@ -60,10 +60,9 @@ func pqQuoteLiteral(in string) string {
 func isMemberOfRole(db QueryAble, role, member string) (bool, error) {
 	var _rez int
 	err := db.QueryRowRetry(
-		func(r *sql.Row) error { return r.Scan(&_rez) },
 		"SELECT 1 FROM pg_auth_members WHERE pg_get_userbyid(roleid) = $1 AND pg_get_userbyid(member) = $2",
 		role, member,
-	)
+	).Scan(&_rez)
 
 	switch {
 	case err == sql.ErrNoRows:
@@ -254,9 +253,8 @@ func getDatabases(db QueryAble) ([]string, error) {
 
 func dbExists(db QueryAble, dbname string) (bool, error) {
 	err := db.QueryRowRetry(
-		func(r *sql.Row) error { return r.Scan(&dbname) },
 		"SELECT datname FROM pg_database WHERE datname=$1", dbname,
-	)
+	).Scan(&dbname)
 	switch {
 	case err == sql.ErrNoRows:
 		return false, nil
@@ -269,9 +267,8 @@ func dbExists(db QueryAble, dbname string) (bool, error) {
 
 func roleExists(db QueryAble, rolname string) (bool, error) {
 	err := db.QueryRowRetry(
-		func(r *sql.Row) error { return r.Scan(&rolname) },
 		"SELECT 1 FROM pg_roles WHERE rolname=$1", rolname,
-	)
+	).Scan(&rolname)
 	switch {
 	case err == sql.ErrNoRows:
 		return false, nil
@@ -284,9 +281,8 @@ func roleExists(db QueryAble, rolname string) (bool, error) {
 
 func schemaExists(db QueryAble, schemaname string) (bool, error) {
 	err := db.QueryRowRetry(
-		func(r *sql.Row) error { return r.Scan(&schemaname) },
 		"SELECT 1 FROM pg_namespace WHERE nspname=$1", schemaname,
-	)
+	).Scan(&schemaname)
 	switch {
 	case err == sql.ErrNoRows:
 		return false, nil
@@ -299,9 +295,8 @@ func schemaExists(db QueryAble, schemaname string) (bool, error) {
 
 func schemaExistsWithDB(db *DBConnection, schemaname string) (bool, error) {
 	err := db.QueryRowRetry(
-		func(r *sql.Row) error { return r.Scan(&schemaname) },
 		"SELECT 1 FROM pg_namespace WHERE nspname=$1", schemaname,
-	)
+	).Scan(&schemaname)
 	switch {
 	case err == sql.ErrNoRows:
 		return false, nil

--- a/postgresql/provider.go
+++ b/postgresql/provider.go
@@ -111,6 +111,20 @@ func Provider() *schema.Provider {
 				Description:  "Maximum number of connections to establish to the database. Zero means unlimited.",
 				ValidateFunc: validation.IntAtLeast(-1),
 			},
+			"max_retries": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      defaultMaxRetries,
+				Description:  "Number of times to retry transient CockroachDB read errors (connection reset, timeout, serialization). Zero disables retries.",
+				ValidateFunc: validation.IntAtLeast(0),
+			},
+			"retry_max_delay_ms": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      30000,
+				Description:  "Maximum backoff delay (in milliseconds) between retry attempts. The actual delay uses full jitter and exponential growth, capped at this value.",
+				ValidateFunc: validation.IntAtLeast(1),
+			},
 			"expected_version": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -173,6 +187,8 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		ApplicationName:   "Terraform provider",
 		ConnectTimeoutSec: d.Get("connect_timeout").(int),
 		MaxConns:          d.Get("max_connections").(int),
+		MaxRetries:        d.Get("max_retries").(int),
+		RetryMaxDelayMs:   d.Get("retry_max_delay_ms").(int),
 		ExpectedVersion:   version,
 		SSLRootCertPath:   d.Get("sslrootcert").(string),
 	}

--- a/postgresql/resource_cockroachdb_changefeed.go
+++ b/postgresql/resource_cockroachdb_changefeed.go
@@ -194,9 +194,8 @@ func resourceCockroachDBChangefeedReadImpl(db *DBConnection, d *schema.ResourceD
 	jobID := d.Id()
 	var sinkUri, jobTableString, description string
 	err := db.QueryRowRetry(
-		func(r *sql.Row) error { return r.Scan(&sinkUri, &jobTableString, &description) },
 		fmt.Sprintf("select sink_uri,topics,description from [show changefeed job %s];", jobID),
-	)
+	).Scan(&sinkUri, &jobTableString, &description)
 	if err != nil {
 		return fmt.Errorf("Can't retrieve job details: %w", err)
 	}
@@ -304,9 +303,8 @@ func jobExists(db QueryAble, jobID string) (bool, error) {
 	// Consider changefeed as existing when running or paused so that
 	// Terraform plans update in-place (or drop+create) instead of "object will be created".
 	err := db.QueryRowRetry(
-		func(r *sql.Row) error { return r.Scan(&jobIDExists) },
 		fmt.Sprintf("SELECT job_id FROM [SHOW changefeed JOB %s] WHERE status IN ('running', 'paused');", jobID),
-	)
+	).Scan(&jobIDExists)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return false, nil
@@ -360,7 +358,7 @@ func waitForJobStatus(db *DBConnection, jobID string, requestedStatus string, ti
 		case <-ticker.C:
 			var status string
 			query := fmt.Sprintf("SELECT status FROM [SHOW JOB %s]", jobID)
-			if err := db.QueryRowRetry(func(r *sql.Row) error { return r.Scan(&status) }, query); err != nil {
+			if err := db.QueryRowRetry(query).Scan(&status); err != nil {
 				return fmt.Errorf("error querying job status: %w", err)
 			}
 

--- a/postgresql/resource_cockroachdb_changefeed.go
+++ b/postgresql/resource_cockroachdb_changefeed.go
@@ -193,7 +193,10 @@ func resourceCockroachDBChangefeedRead(db *DBConnection, d *schema.ResourceData)
 func resourceCockroachDBChangefeedReadImpl(db *DBConnection, d *schema.ResourceData) error {
 	jobID := d.Id()
 	var sinkUri, jobTableString, description string
-	err := db.QueryRow(fmt.Sprintf("select sink_uri,topics,description from [show changefeed job %s];", jobID)).Scan(&sinkUri, &jobTableString, &description)
+	err := db.QueryRowRetry(
+		func(r *sql.Row) error { return r.Scan(&sinkUri, &jobTableString, &description) },
+		fmt.Sprintf("select sink_uri,topics,description from [show changefeed job %s];", jobID),
+	)
 	if err != nil {
 		return fmt.Errorf("Can't retrieve job details: %w", err)
 	}
@@ -300,7 +303,10 @@ func jobExists(db QueryAble, jobID string) (bool, error) {
 	var jobIDExists string
 	// Consider changefeed as existing when running or paused so that
 	// Terraform plans update in-place (or drop+create) instead of "object will be created".
-	err := db.QueryRow(fmt.Sprintf("SELECT job_id FROM [SHOW changefeed JOB %s] WHERE status IN ('running', 'paused');", jobID)).Scan(&jobIDExists)
+	err := db.QueryRowRetry(
+		func(r *sql.Row) error { return r.Scan(&jobIDExists) },
+		fmt.Sprintf("SELECT job_id FROM [SHOW changefeed JOB %s] WHERE status IN ('running', 'paused');", jobID),
+	)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return false, nil
@@ -354,7 +360,7 @@ func waitForJobStatus(db *DBConnection, jobID string, requestedStatus string, ti
 		case <-ticker.C:
 			var status string
 			query := fmt.Sprintf("SELECT status FROM [SHOW JOB %s]", jobID)
-			if err := db.QueryRow(query).Scan(&status); err != nil {
+			if err := db.QueryRowRetry(func(r *sql.Row) error { return r.Scan(&status) }, query); err != nil {
 				return fmt.Errorf("error querying job status: %w", err)
 			}
 

--- a/postgresql/resource_cockroachdb_external_connection.go
+++ b/postgresql/resource_cockroachdb_external_connection.go
@@ -1,7 +1,9 @@
 package postgresql
 
 import (
+	"database/sql"
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -50,7 +52,10 @@ func resourceCockroachDBExternalConnectionRead(db *DBConnection, d *schema.Resou
 func resourceCockroachDBExternalConnectionReadImpl(db *DBConnection, d *schema.ResourceData) error {
 	connName := d.Get(ConnName).(string)
 	var connUrl string
-	if err := db.QueryRow(fmt.Sprintf("select connection_uri from [show external connection %s]", connName)).Scan(&connUrl); err != nil {
+	if err := db.QueryRowRetry(
+		func(r *sql.Row) error { return r.Scan(&connUrl) },
+		fmt.Sprintf("select connection_uri from [show external connection %s]", connName),
+	); err != nil {
 		return fmt.Errorf("Error reading EXTERNAL CONNECTION: %w", err)
 	}
 	d.Set(ConnName, connName)
@@ -72,7 +77,10 @@ func resourceCockroachDBExternalConnectionExists(db *DBConnection, d *schema.Res
 
 func connExists(db QueryAble, connName string) (bool, error) {
 	var exists bool
-	if err := db.QueryRow("SELECT EXISTS(SELECT 1 FROM system.external_connections WHERE connection_name = $1);", connName).Scan(&exists); err != nil {
+	if err := db.QueryRowRetry(
+		func(r *sql.Row) error { return r.Scan(&exists) },
+		"SELECT EXISTS(SELECT 1 FROM system.external_connections WHERE connection_name = $1);", connName,
+	); err != nil {
 		return false, err
 	}
 	return exists, nil

--- a/postgresql/resource_cockroachdb_external_connection.go
+++ b/postgresql/resource_cockroachdb_external_connection.go
@@ -1,7 +1,6 @@
 package postgresql
 
 import (
-	"database/sql"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -53,9 +52,8 @@ func resourceCockroachDBExternalConnectionReadImpl(db *DBConnection, d *schema.R
 	connName := d.Get(ConnName).(string)
 	var connUrl string
 	if err := db.QueryRowRetry(
-		func(r *sql.Row) error { return r.Scan(&connUrl) },
 		fmt.Sprintf("select connection_uri from [show external connection %s]", connName),
-	); err != nil {
+	).Scan(&connUrl); err != nil {
 		return fmt.Errorf("Error reading EXTERNAL CONNECTION: %w", err)
 	}
 	d.Set(ConnName, connName)
@@ -78,9 +76,8 @@ func resourceCockroachDBExternalConnectionExists(db *DBConnection, d *schema.Res
 func connExists(db QueryAble, connName string) (bool, error) {
 	var exists bool
 	if err := db.QueryRowRetry(
-		func(r *sql.Row) error { return r.Scan(&exists) },
 		"SELECT EXISTS(SELECT 1 FROM system.external_connections WHERE connection_name = $1);", connName,
-	); err != nil {
+	).Scan(&exists); err != nil {
 		return false, err
 	}
 	return exists, nil

--- a/postgresql/resource_postgresql_database.go
+++ b/postgresql/resource_postgresql_database.go
@@ -217,9 +217,8 @@ func resourcePostgreSQLDatabaseReadImpl(db *DBConnection, d *schema.ResourceData
 	dbId := d.Id()
 	var dbName, ownerName string
 	err := db.QueryRowRetry(
-		func(r *sql.Row) error { return r.Scan(&dbName, &ownerName) },
 		"SELECT d.datname, pg_catalog.pg_get_userbyid(d.datdba) from pg_database d WHERE datname=$1", dbId,
-	)
+	).Scan(&dbName, &ownerName)
 	switch {
 	case err == sql.ErrNoRows:
 		log.Printf("[WARN] PostgreSQL database (%q) not found", dbId)
@@ -241,16 +240,11 @@ func resourcePostgreSQLDatabaseReadImpl(db *DBConnection, d *schema.ResourceData
 
 	dbSQL := fmt.Sprintf(`SELECT %s FROM pg_catalog.pg_database AS d WHERE d.datname = $1`,
 		strings.Join(columns, ", "))
-	err = db.QueryRowRetry(
-		func(r *sql.Row) error {
-			return r.Scan(
-				&dbEncoding,
-				&dbCollation,
-				&dbCType,
-				&dbConnLimit,
-			)
-		},
-		dbSQL, dbId,
+	err = db.QueryRowRetry(dbSQL, dbId).Scan(
+		&dbEncoding,
+		&dbCollation,
+		&dbCType,
+		&dbConnLimit,
 	)
 	switch {
 	case err == sql.ErrNoRows:

--- a/postgresql/resource_postgresql_database.go
+++ b/postgresql/resource_postgresql_database.go
@@ -216,7 +216,10 @@ func resourcePostgreSQLDatabaseRead(db *DBConnection, d *schema.ResourceData) er
 func resourcePostgreSQLDatabaseReadImpl(db *DBConnection, d *schema.ResourceData) error {
 	dbId := d.Id()
 	var dbName, ownerName string
-	err := db.QueryRow("SELECT d.datname, pg_catalog.pg_get_userbyid(d.datdba) from pg_database d WHERE datname=$1", dbId).Scan(&dbName, &ownerName)
+	err := db.QueryRowRetry(
+		func(r *sql.Row) error { return r.Scan(&dbName, &ownerName) },
+		"SELECT d.datname, pg_catalog.pg_get_userbyid(d.datdba) from pg_database d WHERE datname=$1", dbId,
+	)
 	switch {
 	case err == sql.ErrNoRows:
 		log.Printf("[WARN] PostgreSQL database (%q) not found", dbId)
@@ -238,13 +241,17 @@ func resourcePostgreSQLDatabaseReadImpl(db *DBConnection, d *schema.ResourceData
 
 	dbSQL := fmt.Sprintf(`SELECT %s FROM pg_catalog.pg_database AS d WHERE d.datname = $1`,
 		strings.Join(columns, ", "))
-	err = db.QueryRow(dbSQL, dbId).
-		Scan(
-			&dbEncoding,
-			&dbCollation,
-			&dbCType,
-			&dbConnLimit,
-		)
+	err = db.QueryRowRetry(
+		func(r *sql.Row) error {
+			return r.Scan(
+				&dbEncoding,
+				&dbCollation,
+				&dbCType,
+				&dbConnLimit,
+			)
+		},
+		dbSQL, dbId,
+	)
 	switch {
 	case err == sql.ErrNoRows:
 		log.Printf("[WARN] PostgreSQL database (%q) not found", dbId)

--- a/postgresql/resource_postgresql_default_privileges.go
+++ b/postgresql/resource_postgresql_default_privileges.go
@@ -1,6 +1,7 @@
 package postgresql
 
 import (
+	"database/sql"
 	"fmt"
 	"log"
 	"strings"
@@ -196,7 +197,7 @@ func grantRoleDefaultPrivilegesWithDB(db *DBConnection, d *schema.ResourceData) 
 	if d.Get("with_grant_option").(bool) {
 		query = query + " WITH GRANT OPTION"
 	}
-	if _, err = db.Exec(query); err != nil {
+	if _, err = db.ExecRetry(query); err != nil {
 		return fmt.Errorf("could not alter default privileges: %w", err)
 	}
 
@@ -226,7 +227,7 @@ func revokeRoleDefaultPrivilegesWithDB(db *DBConnection, d *schema.ResourceData)
 		strings.ToUpper(d.Get("object_type").(string)),
 		pq.QuoteIdentifier(d.Get("role").(string)),
 	)
-	if _, err := db.Exec(query); err != nil {
+	if _, err := db.ExecRetry(query); err != nil {
 		return fmt.Errorf("could not revoke default privileges: %w", err)
 	}
 	return nil
@@ -263,7 +264,7 @@ func readRoleDefaultPrivilegesWithDB(db *DBConnection, d *schema.ResourceData) e
 	query = fmt.Sprintf("with a as (show DEFAULT PRIVILEGES for role %s %s) select array_agg(privilege_type) from a where grantee = '%s' and %s;", owner, inSchema, role, objectTypeClause)
 
 	var privileges pq.ByteaArray
-	if err := db.QueryRow(query).Scan(&privileges); err != nil {
+	if err := db.QueryRowRetry(func(r *sql.Row) error { return r.Scan(&privileges) }, query); err != nil {
 		return fmt.Errorf("could not read default privileges: %w", err)
 	}
 

--- a/postgresql/resource_postgresql_default_privileges.go
+++ b/postgresql/resource_postgresql_default_privileges.go
@@ -1,7 +1,6 @@
 package postgresql
 
 import (
-	"database/sql"
 	"fmt"
 	"log"
 	"strings"
@@ -264,7 +263,7 @@ func readRoleDefaultPrivilegesWithDB(db *DBConnection, d *schema.ResourceData) e
 	query = fmt.Sprintf("with a as (show DEFAULT PRIVILEGES for role %s %s) select array_agg(privilege_type) from a where grantee = '%s' and %s;", owner, inSchema, role, objectTypeClause)
 
 	var privileges pq.ByteaArray
-	if err := db.QueryRowRetry(func(r *sql.Row) error { return r.Scan(&privileges) }, query); err != nil {
+	if err := db.QueryRowRetry(query).Scan(&privileges); err != nil {
 		return fmt.Errorf("could not read default privileges: %w", err)
 	}
 

--- a/postgresql/resource_postgresql_function.go
+++ b/postgresql/resource_postgresql_function.go
@@ -228,7 +228,7 @@ func resourcePostgreSQLFunctionExists(db *DBConnection, d *schema.ResourceData) 
 
 	query := fmt.Sprintf("SELECT to_regprocedure('%s') IS NOT NULL AS functionExists", functionSignature)
 
-	if err := dbConn.QueryRowRetry(func(r *sql.Row) error { return r.Scan(&functionExists) }, query); err != nil {
+	if err := dbConn.QueryRowRetry(query).Scan(&functionExists); err != nil {
 		return false, err
 	}
 
@@ -275,7 +275,7 @@ func resourcePostgreSQLFunctionReadImpl(db *DBConnection, d *schema.ResourceData
 		return err
 	}
 
-	err = dbConn.QueryRowRetry(func(r *sql.Row) error { return r.Scan(&funcDefinition) }, query, functionSignature)
+	err = dbConn.QueryRowRetry(query, functionSignature).Scan(&funcDefinition)
 	switch {
 	case err == sql.ErrNoRows:
 		log.Printf("[WARN] PostgreSQL function: %s", functionId)

--- a/postgresql/resource_postgresql_function.go
+++ b/postgresql/resource_postgresql_function.go
@@ -228,7 +228,7 @@ func resourcePostgreSQLFunctionExists(db *DBConnection, d *schema.ResourceData) 
 
 	query := fmt.Sprintf("SELECT to_regprocedure('%s') IS NOT NULL AS functionExists", functionSignature)
 
-	if err := dbConn.QueryRow(query).Scan(&functionExists); err != nil {
+	if err := dbConn.QueryRowRetry(func(r *sql.Row) error { return r.Scan(&functionExists) }, query); err != nil {
 		return false, err
 	}
 
@@ -275,7 +275,7 @@ func resourcePostgreSQLFunctionReadImpl(db *DBConnection, d *schema.ResourceData
 		return err
 	}
 
-	err = dbConn.QueryRow(query, functionSignature).Scan(&funcDefinition)
+	err = dbConn.QueryRowRetry(func(r *sql.Row) error { return r.Scan(&funcDefinition) }, query, functionSignature)
 	switch {
 	case err == sql.ErrNoRows:
 		log.Printf("[WARN] PostgreSQL function: %s", functionId)

--- a/postgresql/resource_postgresql_grant.go
+++ b/postgresql/resource_postgresql_grant.go
@@ -172,7 +172,7 @@ func readSystemRolePriviges(db QueryAble, role string) error {
 	var query string
 	var privileges pq.ByteaArray
 	query = fmt.Sprintf(`with a as (show system grants for %s) select array_agg(privilege_type) from a`, role)
-	if err := db.QueryRow(query).Scan(&privileges); err != nil {
+	if err := db.QueryRowRetry(func(r *sql.Row) error { return r.Scan(&privileges) }, query); err != nil {
 		return fmt.Errorf("could not read system privileges: %w", err)
 	}
 	return nil
@@ -182,7 +182,7 @@ func readDatabaseRolePriviges(db QueryAble, d *schema.ResourceData, role string)
 	dbName := d.Get("database").(string)
 	var privileges pq.ByteaArray
 	query := fmt.Sprintf(`with a as (show grants on database %s for %s) select array_agg(privilege_type) from a where grantee=%s`, pq.QuoteIdentifier(dbName), pq.QuoteIdentifier(role), pq.QuoteLiteral(role))
-	if err := db.QueryRow(query).Scan(&privileges); err != nil {
+	if err := db.QueryRowRetry(func(r *sql.Row) error { return r.Scan(&privileges) }, query); err != nil {
 		return fmt.Errorf("could not read privileges for database %s: %w", dbName, err)
 	}
 
@@ -194,7 +194,7 @@ func readSchemaRolePriviges(db QueryAble, d *schema.ResourceData, role string) e
 	schemaName := d.Get("schema").(string)
 	var privileges pq.ByteaArray
 	query := fmt.Sprintf(`with a as ( show grants on schema %s for %s) select array_agg(privilege_type) from a where grantee=%s;`, pq.QuoteIdentifier(schemaName), pq.QuoteIdentifier(role), pq.QuoteLiteral(role))
-	if err := db.QueryRow(query).Scan(&privileges); err != nil {
+	if err := db.QueryRowRetry(func(r *sql.Row) error { return r.Scan(&privileges) }, query); err != nil {
 		return fmt.Errorf("could not read privileges for schema %s: %w", schemaName, err)
 	}
 
@@ -229,11 +229,11 @@ WHERE routine_schema = %s
 AND grantee = %s
 GROUP BY routine_name`,
 			pq.QuoteLiteral(d.Get("schema").(string)), pq.QuoteLiteral(role))
-		rows, err = db.Query(query)
+		rows, err = db.QueryRetry(query)
 
 	default:
 		query = fmt.Sprintf("with a as (show tables from %s) , b as (show grants on table * for %s) select a.table_name,  array_agg(privilege_type) from a inner join b on a.table_name=b.table_name and a.schema_name = b.schema_name  where a.type='%s'  and grantee= %s group by a.table_name;", pq.QuoteIdentifier(d.Get("schema").(string)), pq.QuoteIdentifier(role), objectType, pq.QuoteLiteral(role))
-		rows, err = db.Query(query)
+		rows, err = db.QueryRetry(query)
 	}
 
 	// This returns, for the specified role (rolname),
@@ -396,7 +396,7 @@ func grantRolePrivilegesWithDB(db *DBConnection, d *schema.ResourceData) error {
 
 	query := createGrantQuery(d, privileges)
 
-	_, err := db.Exec(query)
+	_, err := db.ExecRetry(query)
 	return err
 }
 
@@ -407,7 +407,7 @@ func revokeRolePrivilegesWithDB(db *DBConnection, d *schema.ResourceData) error 
 		// Query is empty, don't run anything
 		return nil
 	}
-	if _, err := db.Exec(query); err != nil {
+	if _, err := db.ExecRetry(query); err != nil {
 		return fmt.Errorf("could not execute revoke query: %w", err)
 	}
 	return nil

--- a/postgresql/resource_postgresql_grant.go
+++ b/postgresql/resource_postgresql_grant.go
@@ -172,7 +172,7 @@ func readSystemRolePriviges(db QueryAble, role string) error {
 	var query string
 	var privileges pq.ByteaArray
 	query = fmt.Sprintf(`with a as (show system grants for %s) select array_agg(privilege_type) from a`, role)
-	if err := db.QueryRowRetry(func(r *sql.Row) error { return r.Scan(&privileges) }, query); err != nil {
+	if err := db.QueryRowRetry(query).Scan(&privileges); err != nil {
 		return fmt.Errorf("could not read system privileges: %w", err)
 	}
 	return nil
@@ -182,7 +182,7 @@ func readDatabaseRolePriviges(db QueryAble, d *schema.ResourceData, role string)
 	dbName := d.Get("database").(string)
 	var privileges pq.ByteaArray
 	query := fmt.Sprintf(`with a as (show grants on database %s for %s) select array_agg(privilege_type) from a where grantee=%s`, pq.QuoteIdentifier(dbName), pq.QuoteIdentifier(role), pq.QuoteLiteral(role))
-	if err := db.QueryRowRetry(func(r *sql.Row) error { return r.Scan(&privileges) }, query); err != nil {
+	if err := db.QueryRowRetry(query).Scan(&privileges); err != nil {
 		return fmt.Errorf("could not read privileges for database %s: %w", dbName, err)
 	}
 
@@ -194,7 +194,7 @@ func readSchemaRolePriviges(db QueryAble, d *schema.ResourceData, role string) e
 	schemaName := d.Get("schema").(string)
 	var privileges pq.ByteaArray
 	query := fmt.Sprintf(`with a as ( show grants on schema %s for %s) select array_agg(privilege_type) from a where grantee=%s;`, pq.QuoteIdentifier(schemaName), pq.QuoteIdentifier(role), pq.QuoteLiteral(role))
-	if err := db.QueryRowRetry(func(r *sql.Row) error { return r.Scan(&privileges) }, query); err != nil {
+	if err := db.QueryRowRetry(query).Scan(&privileges); err != nil {
 		return fmt.Errorf("could not read privileges for schema %s: %w", schemaName, err)
 	}
 

--- a/postgresql/resource_postgresql_grant_role.go
+++ b/postgresql/resource_postgresql_grant_role.go
@@ -101,7 +101,7 @@ func readGrantRole(db *DBConnection, d *schema.ResourceData) error {
 
 	query := fmt.Sprintf(` with a as (show grants on role %s for %s) select member as role , role_name as grant_role, is_admin as with_admin_option from a;
 `, pq.QuoteIdentifier(d.Get("grant_role").(string)), pq.QuoteIdentifier(d.Get("role").(string)))
-	err := db.QueryRowRetry(func(r *sql.Row) error { return r.Scan(values...) }, query)
+	err := db.QueryRowRetry(query).Scan(values...)
 	switch {
 	case err == sql.ErrNoRows:
 		log.Printf("[WARN] PostgreSQL grant role %s for %s not found, removing from state", d.Get("grant_role"), d.Get("role"))

--- a/postgresql/resource_postgresql_grant_role.go
+++ b/postgresql/resource_postgresql_grant_role.go
@@ -101,7 +101,7 @@ func readGrantRole(db *DBConnection, d *schema.ResourceData) error {
 
 	query := fmt.Sprintf(` with a as (show grants on role %s for %s) select member as role , role_name as grant_role, is_admin as with_admin_option from a;
 `, pq.QuoteIdentifier(d.Get("grant_role").(string)), pq.QuoteIdentifier(d.Get("role").(string)))
-	err := db.QueryRow(query).Scan(values...)
+	err := db.QueryRowRetry(func(r *sql.Row) error { return r.Scan(values...) }, query)
 	switch {
 	case err == sql.ErrNoRows:
 		log.Printf("[WARN] PostgreSQL grant role %s for %s not found, removing from state", d.Get("grant_role"), d.Get("role"))
@@ -144,7 +144,7 @@ func createRevokeRoleQuery(d *schema.ResourceData) string {
 // grantRoleWithDB grants a role using the DB connection directly
 func grantRoleWithDB(db *DBConnection, d *schema.ResourceData) error {
 	query := createGrantRoleQuery(d)
-	if _, err := db.Exec(query); err != nil {
+	if _, err := db.ExecRetry(query); err != nil {
 		return fmt.Errorf("could not execute grant query: %w", err)
 	}
 	return nil
@@ -153,7 +153,7 @@ func grantRoleWithDB(db *DBConnection, d *schema.ResourceData) error {
 // revokeRoleWithDB revokes a role using the DB connection directly
 func revokeRoleWithDB(db *DBConnection, d *schema.ResourceData) error {
 	query := createRevokeRoleQuery(d)
-	if _, err := db.Exec(query); err != nil {
+	if _, err := db.ExecRetry(query); err != nil {
 		// Ignore error if the role is not a member (for CockroachDB compatibility)
 		if !strings.Contains(err.Error(), "is not a member") {
 			return fmt.Errorf("could not execute revoke query: %w", err)

--- a/postgresql/resource_postgresql_role.go
+++ b/postgresql/resource_postgresql_role.go
@@ -294,9 +294,8 @@ func resourcePostgreSQLRoleDelete(db *DBConnection, d *schema.ResourceData) erro
 func resourcePostgreSQLRoleExists(db *DBConnection, d *schema.ResourceData) (bool, error) {
 	var roleName string
 	err := db.QueryRowRetry(
-		func(r *sql.Row) error { return r.Scan(&roleName) },
 		"SELECT rolname FROM pg_catalog.pg_roles WHERE rolname=$1", d.Id(),
-	)
+	).Scan(&roleName)
 	switch {
 	case err == sql.ErrNoRows:
 		return false, nil
@@ -348,7 +347,7 @@ func resourcePostgreSQLRoleReadImpl(db *DBConnection, d *schema.ResourceData) er
 		// select columns
 		strings.Join(columns, ", "),
 	)
-	err := db.QueryRowRetry(func(r *sql.Row) error { return r.Scan(values...) }, roleSQL, roleID)
+	err := db.QueryRowRetry(roleSQL, roleID).Scan(values...)
 
 	switch {
 	case err == sql.ErrNoRows:
@@ -364,8 +363,7 @@ func resourcePostgreSQLRoleReadImpl(db *DBConnection, d *schema.ResourceData) er
 	var roleConfig pq.ByteaArray
 	settingSQL := `SELECT setconfig FROM pg_catalog.pg_db_role_setting
 		WHERE setrole = (SELECT oid FROM pg_catalog.pg_roles WHERE rolname=$1) AND setdatabase = 0`
-	settingErr := db.QueryRowRetry(func(r *sql.Row) error { return r.Scan(&roleConfig) }, settingSQL, roleID)
-	if settingErr != nil && settingErr != sql.ErrNoRows {
+	if settingErr := db.QueryRowRetry(settingSQL, roleID).Scan(&roleConfig); settingErr != nil && settingErr != sql.ErrNoRows {
 		return fmt.Errorf("Error reading role settings from pg_db_role_setting: %w", settingErr)
 	}
 	// If settingErr == sql.ErrNoRows, roleConfig remains nil — no settings configured.

--- a/postgresql/resource_postgresql_role.go
+++ b/postgresql/resource_postgresql_role.go
@@ -293,7 +293,10 @@ func resourcePostgreSQLRoleDelete(db *DBConnection, d *schema.ResourceData) erro
 
 func resourcePostgreSQLRoleExists(db *DBConnection, d *schema.ResourceData) (bool, error) {
 	var roleName string
-	err := db.QueryRow("SELECT rolname FROM pg_catalog.pg_roles WHERE rolname=$1", d.Id()).Scan(&roleName)
+	err := db.QueryRowRetry(
+		func(r *sql.Row) error { return r.Scan(&roleName) },
+		"SELECT rolname FROM pg_catalog.pg_roles WHERE rolname=$1", d.Id(),
+	)
 	switch {
 	case err == sql.ErrNoRows:
 		return false, nil
@@ -345,7 +348,7 @@ func resourcePostgreSQLRoleReadImpl(db *DBConnection, d *schema.ResourceData) er
 		// select columns
 		strings.Join(columns, ", "),
 	)
-	err := db.QueryRow(roleSQL, roleID).Scan(values...)
+	err := db.QueryRowRetry(func(r *sql.Row) error { return r.Scan(values...) }, roleSQL, roleID)
 
 	switch {
 	case err == sql.ErrNoRows:
@@ -361,7 +364,8 @@ func resourcePostgreSQLRoleReadImpl(db *DBConnection, d *schema.ResourceData) er
 	var roleConfig pq.ByteaArray
 	settingSQL := `SELECT setconfig FROM pg_catalog.pg_db_role_setting
 		WHERE setrole = (SELECT oid FROM pg_catalog.pg_roles WHERE rolname=$1) AND setdatabase = 0`
-	if settingErr := db.QueryRow(settingSQL, roleID).Scan(&roleConfig); settingErr != nil && settingErr != sql.ErrNoRows {
+	settingErr := db.QueryRowRetry(func(r *sql.Row) error { return r.Scan(&roleConfig) }, settingSQL, roleID)
+	if settingErr != nil && settingErr != sql.ErrNoRows {
 		return fmt.Errorf("Error reading role settings from pg_db_role_setting: %w", settingErr)
 	}
 	// If settingErr == sql.ErrNoRows, roleConfig remains nil — no settings configured.
@@ -681,7 +685,7 @@ func revokeRoles(db QueryAble, d *schema.ResourceData) error {
 		JOIN pg_catalog.pg_roles ON members.member = pg_roles.oid
 		WHERE rolname = $1`
 
-	rows, err := db.Query(query, role)
+	rows, err := db.QueryRetry(query, role)
 	if err != nil {
 		return fmt.Errorf("could not get roles list for role %s: %w", role, err)
 	}

--- a/postgresql/resource_postgresql_schema.go
+++ b/postgresql/resource_postgresql_schema.go
@@ -94,9 +94,8 @@ func createSchemaWithDB(db *DBConnection, d *schema.ResourceData) error {
 	// Check if previous tasks haven't already created schema
 	var foundSchema bool
 	err := db.QueryRowRetry(
-		func(r *sql.Row) error { return r.Scan(&foundSchema) },
 		`SELECT TRUE FROM pg_catalog.pg_namespace WHERE nspname = $1`, schemaName,
-	)
+	).Scan(&foundSchema)
 
 	queries := []string{}
 	switch {
@@ -209,9 +208,8 @@ func resourcePostgreSQLSchemaExists(db *DBConnection, d *schema.ResourceData) (b
 	}
 
 	err = dbConn.QueryRowRetry(
-		func(r *sql.Row) error { return r.Scan(&schemaName) },
 		"SELECT n.nspname FROM pg_catalog.pg_namespace n WHERE n.nspname=$1", schemaName,
-	)
+	).Scan(&schemaName)
 	switch {
 	case err == sql.ErrNoRows:
 		return false, nil
@@ -239,9 +237,8 @@ func resourcePostgreSQLSchemaReadImpl(db *DBConnection, d *schema.ResourceData) 
 
 	var schemaOwner string
 	err = dbConn.QueryRowRetry(
-		func(r *sql.Row) error { return r.Scan(&schemaOwner) },
 		"SELECT pg_catalog.pg_get_userbyid(n.nspowner) FROM pg_catalog.pg_namespace n WHERE n.nspname=$1", schemaName,
-	)
+	).Scan(&schemaOwner)
 	switch {
 	case err == sql.ErrNoRows:
 		log.Printf("[WARN] PostgreSQL schema (%s) not found in database %s", schemaName, database)

--- a/postgresql/resource_postgresql_schema.go
+++ b/postgresql/resource_postgresql_schema.go
@@ -93,7 +93,10 @@ func createSchemaWithDB(db *DBConnection, d *schema.ResourceData) error {
 
 	// Check if previous tasks haven't already created schema
 	var foundSchema bool
-	err := db.QueryRow(`SELECT TRUE FROM pg_catalog.pg_namespace WHERE nspname = $1`, schemaName).Scan(&foundSchema)
+	err := db.QueryRowRetry(
+		func(r *sql.Row) error { return r.Scan(&foundSchema) },
+		`SELECT TRUE FROM pg_catalog.pg_namespace WHERE nspname = $1`, schemaName,
+	)
 
 	queries := []string{}
 	switch {
@@ -205,7 +208,10 @@ func resourcePostgreSQLSchemaExists(db *DBConnection, d *schema.ResourceData) (b
 		return false, err
 	}
 
-	err = dbConn.QueryRow("SELECT n.nspname FROM pg_catalog.pg_namespace n WHERE n.nspname=$1", schemaName).Scan(&schemaName)
+	err = dbConn.QueryRowRetry(
+		func(r *sql.Row) error { return r.Scan(&schemaName) },
+		"SELECT n.nspname FROM pg_catalog.pg_namespace n WHERE n.nspname=$1", schemaName,
+	)
 	switch {
 	case err == sql.ErrNoRows:
 		return false, nil
@@ -232,7 +238,10 @@ func resourcePostgreSQLSchemaReadImpl(db *DBConnection, d *schema.ResourceData) 
 	}
 
 	var schemaOwner string
-	err = dbConn.QueryRow("SELECT pg_catalog.pg_get_userbyid(n.nspowner) FROM pg_catalog.pg_namespace n WHERE n.nspname=$1", schemaName).Scan(&schemaOwner)
+	err = dbConn.QueryRowRetry(
+		func(r *sql.Row) error { return r.Scan(&schemaOwner) },
+		"SELECT pg_catalog.pg_get_userbyid(n.nspowner) FROM pg_catalog.pg_namespace n WHERE n.nspname=$1", schemaName,
+	)
 	switch {
 	case err == sql.ErrNoRows:
 		log.Printf("[WARN] PostgreSQL schema (%s) not found in database %s", schemaName, database)

--- a/postgresql/retry.go
+++ b/postgresql/retry.go
@@ -136,12 +136,25 @@ func (db *DBConnection) QueryRetry(query string, args ...interface{}) (*sql.Rows
 	return rows, err
 }
 
-// QueryRowRetry wraps db.QueryRow. Because lib/pq defers query execution until
-// Scan(), we run the actual query+scan inside the retry by accepting a scan
-// closure. The closure must populate the destination from the row.
-func (db *DBConnection) QueryRowRetry(scan func(*sql.Row) error, query string, args ...interface{}) error {
-	return db.retry("QueryRow", func() error {
-		return scan(db.DB.QueryRow(query, args...))
+// RetryRow defers query+scan until Scan() is called so the whole network
+// round-trip can be retried as a unit. Mirrors *sql.Row's Scan signature so
+// QueryRowRetry is a drop-in replacement for QueryRow.
+type RetryRow struct {
+	db    *DBConnection
+	query string
+	args  []interface{}
+}
+
+// QueryRowRetry returns a RetryRow whose Scan retries transient errors.
+func (db *DBConnection) QueryRowRetry(query string, args ...interface{}) *RetryRow {
+	return &RetryRow{db: db, query: query, args: args}
+}
+
+// Scan executes the deferred query and scans the resulting row into dest,
+// retrying on transient errors. sql.ErrNoRows is returned unchanged.
+func (r *RetryRow) Scan(dest ...interface{}) error {
+	return r.db.retry("QueryRow", func() error {
+		return r.db.DB.QueryRow(r.query, r.args...).Scan(dest...)
 	})
 }
 

--- a/postgresql/retry.go
+++ b/postgresql/retry.go
@@ -1,0 +1,163 @@
+package postgresql
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"io"
+	"log"
+	"math/rand"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/lib/pq"
+)
+
+const (
+	defaultMaxRetries     = 5
+	defaultRetryBaseDelay = 100 * time.Millisecond
+	defaultRetryMaxDelay  = 30 * time.Second
+)
+
+// isTransientError reports whether err looks like a recoverable network or
+// CockroachDB-side retry signal. The CRDB cluster behind a load balancer is the
+// primary source of these errors during long refresh phases — connections get
+// reset by peer, idle-reaped, or hit serialization retry conditions.
+func isTransientError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	if errors.Is(err, driver.ErrBadConn) || errors.Is(err, io.EOF) {
+		return true
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		if netErr.Timeout() {
+			return true
+		}
+	}
+
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		return true
+	}
+
+	var pqErr *pq.Error
+	if errors.As(err, &pqErr) {
+		// CRDB serialization / retry codes plus connection-failure class.
+		switch pqErr.Code.Class() {
+		case "08", // connection exception
+			"57": // operator intervention (e.g. admin shutdown)
+			return true
+		}
+		switch string(pqErr.Code) {
+		case "40001", // serialization_failure
+			"40003", // statement_completion_unknown
+			"XXC00": // crdb retry txn
+			return true
+		}
+	}
+
+	msg := err.Error()
+	if strings.Contains(msg, "connection reset by peer") ||
+		strings.Contains(msg, "connection timed out") ||
+		strings.Contains(msg, "broken pipe") ||
+		strings.Contains(msg, "use of closed network connection") ||
+		strings.Contains(msg, "bad connection") ||
+		strings.Contains(msg, "EOF") {
+		return true
+	}
+
+	return false
+}
+
+// retryBackoff returns the sleep duration before attempt n (1-indexed),
+// using exponential backoff with full jitter, capped at maxDelay.
+func retryBackoff(attempt int, base, maxDelay time.Duration) time.Duration {
+	if attempt < 1 {
+		attempt = 1
+	}
+	// 2^(attempt-1) * base, capped.
+	d := base << uint(attempt-1)
+	if d <= 0 || d > maxDelay {
+		d = maxDelay
+	}
+	// Full jitter: random in [0, d].
+	return time.Duration(rand.Int63n(int64(d) + 1))
+}
+
+// retry runs fn up to maxRetries+1 times, sleeping between attempts on
+// transient errors. Non-transient errors return immediately.
+func (db *DBConnection) retry(label string, fn func() error) error {
+	maxRetries := db.client.config.MaxRetries
+	if maxRetries < 0 {
+		maxRetries = 0
+	}
+	maxDelay := time.Duration(db.client.config.RetryMaxDelayMs) * time.Millisecond
+	if maxDelay <= 0 {
+		maxDelay = defaultRetryMaxDelay
+	}
+
+	var lastErr error
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		err := fn()
+		if err == nil {
+			return nil
+		}
+		if !isTransientError(err) {
+			return err
+		}
+		lastErr = err
+		if attempt == maxRetries {
+			break
+		}
+		sleep := retryBackoff(attempt+1, defaultRetryBaseDelay, maxDelay)
+		log.Printf("[WARN] %s: transient error (attempt %d/%d), retrying in %s: %v",
+			label, attempt+1, maxRetries+1, sleep, err)
+		time.Sleep(sleep)
+	}
+	return lastErr
+}
+
+// QueryRetry wraps db.Query with transient-error retry.
+func (db *DBConnection) QueryRetry(query string, args ...interface{}) (*sql.Rows, error) {
+	var rows *sql.Rows
+	err := db.retry("Query", func() error {
+		r, qerr := db.DB.Query(query, args...)
+		if qerr != nil {
+			return qerr
+		}
+		rows = r
+		return nil
+	})
+	return rows, err
+}
+
+// QueryRowRetry wraps db.QueryRow. Because lib/pq defers query execution until
+// Scan(), we run the actual query+scan inside the retry by accepting a scan
+// closure. The closure must populate the destination from the row.
+func (db *DBConnection) QueryRowRetry(scan func(*sql.Row) error, query string, args ...interface{}) error {
+	return db.retry("QueryRow", func() error {
+		return scan(db.DB.QueryRow(query, args...))
+	})
+}
+
+// ExecRetry wraps db.Exec with transient-error retry. Callers must ensure the
+// statement is safe to retry (idempotent). Pre-execution transient failures
+// (connect-time / ErrBadConn) are always safe; for mid-statement failures the
+// retry assumes the caller knows the statement is replay-safe.
+func (db *DBConnection) ExecRetry(query string, args ...interface{}) (sql.Result, error) {
+	var res sql.Result
+	err := db.retry("Exec", func() error {
+		r, eerr := db.DB.Exec(query, args...)
+		if eerr != nil {
+			return eerr
+		}
+		res = r
+		return nil
+	})
+	return res, err
+}

--- a/postgresql/retry_test.go
+++ b/postgresql/retry_test.go
@@ -1,0 +1,94 @@
+package postgresql
+
+import (
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/lib/pq"
+)
+
+func TestIsTransientError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"driver.ErrBadConn", driver.ErrBadConn, true},
+		{"wrapped ErrBadConn", fmt.Errorf("query failed: %w", driver.ErrBadConn), true},
+		{"io.EOF", io.EOF, true},
+		{"net.OpError", &net.OpError{Op: "read", Err: errors.New("connection reset by peer")}, true},
+		{"connection reset message", errors.New("read tcp 1.2.3.4:5->6.7.8.9:10: read: connection reset by peer"), true},
+		{"connection timed out message", errors.New("read tcp 1.2.3.4:5->6.7.8.9:10: read: connection timed out"), true},
+		{"broken pipe", errors.New("write tcp 1.2.3.4:5: broken pipe"), true},
+		{"use of closed network connection", errors.New("use of closed network connection"), true},
+		{"pq serialization_failure", &pq.Error{Code: "40001"}, true},
+		{"pq connection exception class", &pq.Error{Code: "08006"}, true},
+		{"pq crdb retry", &pq.Error{Code: "XXC00"}, true},
+		{"plain syntax error", errors.New("syntax error at or near FOO"), false},
+		{"pq undefined_table", &pq.Error{Code: "42P01"}, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isTransientError(tc.err)
+			if got != tc.want {
+				t.Errorf("isTransientError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRetryBackoffCap(t *testing.T) {
+	base := 100 * time.Millisecond
+	maxDelay := 5 * time.Second
+
+	// With full jitter, the returned value is in [0, cap], where cap = min(2^(n-1)*base, maxDelay).
+	// Verify the upper bound holds at every attempt and never overshoots maxDelay.
+	for attempt := 1; attempt <= 20; attempt++ {
+		for i := 0; i < 50; i++ {
+			d := retryBackoff(attempt, base, maxDelay)
+			if d < 0 {
+				t.Fatalf("attempt %d: got negative delay %v", attempt, d)
+			}
+			if d > maxDelay {
+				t.Fatalf("attempt %d: delay %v exceeded max %v", attempt, d, maxDelay)
+			}
+		}
+	}
+}
+
+func TestRetryBackoffGrowsThenCaps(t *testing.T) {
+	base := 10 * time.Millisecond
+	maxDelay := 1 * time.Second
+
+	// At attempt 1: ceiling = base = 10ms.
+	// At attempt 7: ceiling = base * 2^6 = 640ms.
+	// At attempt 8+: ceiling clamped to maxDelay = 1s.
+	// Sanity-check that max-sampled values from many trials show growth and cap.
+	maxObserved := func(attempt int) time.Duration {
+		var m time.Duration
+		for i := 0; i < 200; i++ {
+			d := retryBackoff(attempt, base, maxDelay)
+			if d > m {
+				m = d
+			}
+		}
+		return m
+	}
+
+	d1 := maxObserved(1)
+	d4 := maxObserved(4)
+	if d4 < d1 {
+		t.Errorf("expected attempt 4 ceiling to be larger than attempt 1, got %v < %v", d4, d1)
+	}
+	d10 := maxObserved(10)
+	if d10 > maxDelay {
+		t.Errorf("attempt 10 sample %v exceeded cap %v", d10, maxDelay)
+	}
+}


### PR DESCRIPTION
## Summary
- Long terraform refreshes against a load-balanced CRDB cluster were failing with `read tcp ...: connection reset by peer` / `connection timed out` mid-query — a single TCP error aborted the entire apply (see [terraform-cockroachdb PR #822 post-merge run](https://github.com/Riskified/terraform-cockroachdb/actions/runs/26578668495)).
- Adds retry wrappers with exponential backoff + full jitter around every read and every idempotent write, plus connection-lifecycle tuning so transient network failures recover automatically.
- Adds provider knobs `max_retries` (default 5) and `retry_max_delay_ms` (default 30 000).

## What changed
- **New `retry.go`** — `isTransientError` (TCP reset/timeout, `driver.ErrBadConn`, `io.EOF`, `*net.OpError`, pq class `08`/`57`, CRDB retry codes `40001`/`40003`/`XXC00`); `retryBackoff` (exp + full jitter, capped); `QueryRetry`, `QueryRowRetry`, `ExecRetry` on `*DBConnection`.
- **Connection lifecycle** (`config.go`) — `SetConnMaxLifetime(5m)` + `SetConnMaxIdleTime(30s)` so connections rotate ahead of LB / CRDB idle reapers.
- **Provider schema** (`provider.go`) — `max_retries`, `retry_max_delay_ms` plumbed into `Config`.
- **All reads routed** through `QueryRetry` / `QueryRowRetry` across resources, data sources, and helpers. `QueryAble` interface extended.
- **Idempotent Exec routed** through `ExecRetry`: GRANT / REVOKE / ALTER DEFAULT PRIVILEGES, role membership grant/revoke.
- **Intentionally NOT wrapped**: `CREATE CHANGEFEED` (not idempotent), `fingerprintCapabilities` bootstrap query (fail-fast desired).

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `make fmt` — applied
- [x] `go test ./postgresql/ -run 'Test[^A]' -count=1` — unit tests pass (incl. new classification + backoff tests in `retry_test.go`)
- [ ] Acceptance tests against a local CRDB container (`CRDB_IMAGE_TAG=latest-v24.3 docker compose up -d cockroachdb && TF_ACC=1 PGHOST=... go test ./postgresql/...`)
- [ ] Smoke-test against staging by re-running a previously-failing terraform-cockroachdb apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)