### PR TITLE
DEV-128387: Install Terraform CLI in CI instead of letting tests download it

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,11 @@ jobs:
         with:
           go-version: '1.25'
 
+      - name: Set up Terraform CLI
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+
       - name: test
         run: make test
 


### PR DESCRIPTION
## Summary
- Acceptance tests have been failing across the whole CRDB matrix (24.3 / 25.2 / 25.4 / 26.1) since shortly after PR #38 (2026-04-10).
- Failure happens before any test body runs:
  ```
  failed to find or install Terraform CLI: unable to verify checksums signature: openpgp: key expired
  ```
- `terraform-plugin-sdk` auto-downloads the Terraform CLI on first acceptance test and verifies HashiCorp's PGP signature using the keyring bundled in `hc-install`. That key has expired.

## Fix
Add `hashicorp/setup-terraform@v3` to `.github/workflows/test.yml` so the CLI is installed by the action and present on `PATH`. The plugin SDK's lookup order is `TF_ACC_TERRAFORM_PATH` → `PATH` → download — so it picks up the pre-installed binary and the expired-key path is never reached.

`terraform_wrapper: false` is set so the bare `terraform` binary lands on `PATH` (the default wrapper would shim every invocation and isn't what the SDK expects).

## Test plan
- [ ] CI passes on this PR across all four matrix CRDB versions
- [ ] Confirms #39 can then be rebased and merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)